### PR TITLE
Explicitly specify Julia versions to build against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ os:
   - linux
   - osx
 julia:
-  - release
   - 0.5
+  - 0.6
+  - nightly
 notifications:
   email: false
 addons:


### PR DESCRIPTION
This is now best practice since release is a moving target.