### PR TITLE
Attempt to only run codecov/coveralls on Linux build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,10 @@ script:
     - if [[ `uname` = "Linux" ]]; then $TESTCMD -e 'map(Pkg.add, ["Plots", "Images", "ImageView", "StatsBase"])'; fi
     - if [[ `uname` = "Linux" ]]; then $TESTCMD -e 'include(joinpath("src", "GraphicsExamples.jl")); plotbifurcationdiagram("Log", 0.4, 0.8, 10)'; fi
 after_success:
-    - julia -e 'Pkg.add("Documenter")'
-    - $TESTCMD 'cd(Pkg.dir("FeigenbaumUtil")); include(joinpath("docs", "make.jl"))'
+    - if [[ `uname` = "Linux" ]]; then julia -e 'Pkg.add("Documenter")'; fi
+    - if [[ `uname` = "Linux" ]]; then $TESTCMD 'cd(Pkg.dir("FeigenbaumUtil")); include(joinpath("docs", "make.jl"))'; fi
     # push coverage results to Coveralls
-    - julia -e 'cd(Pkg.dir("FeigenbaumUtil")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+    - if [[ `uname` = "Linux" ]]; then julia -e 'cd(Pkg.dir("FeigenbaumUtil")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi
     # push coverage results to Codecov
-    - julia -e 'cd(Pkg.dir("FeigenbaumUtil")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+    - if [[ `uname` = "Linux" ]]; then julia -e 'cd(Pkg.dir("FeigenbaumUtil")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'; fi
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,17 @@ addons:
 # uncomment the following lines to override the default test script
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi
+    - if [ $TRAVIS_OS_NAME = "linux" ]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi
     - $TESTCMD -e 'Pkg.clone(pwd());
           Pkg.build("FeigenbaumUtil");
           Pkg.test("FeigenbaumUtil"; coverage=true)'
-    - if [[ `uname` = "Linux" ]]; then $TESTCMD -e 'map(Pkg.add, ["Plots", "Images", "ImageView", "StatsBase"])'; fi
-    - if [[ `uname` = "Linux" ]]; then $TESTCMD -e 'include(joinpath("src", "GraphicsExamples.jl")); plotbifurcationdiagram("Log", 0.4, 0.8, 10)'; fi
+    - if [ $TRAVIS_OS_NAME = "linux" ]; then $TESTCMD -e 'map(Pkg.add, ["Plots", "Images", "ImageView", "StatsBase"])'; fi
+    - if [ $TRAVIS_OS_NAME = "linux" ]; then $TESTCMD -e 'include(joinpath("src", "GraphicsExamples.jl")); plotbifurcationdiagram("Log", 0.4, 0.8, 10)'; fi
 after_success:
-    - if [[ `uname` = "Linux" ]]; then julia -e 'Pkg.add("Documenter")'; fi
-    - if [[ `uname` = "Linux" ]]; then $TESTCMD 'cd(Pkg.dir("FeigenbaumUtil")); include(joinpath("docs", "make.jl"))'; fi
+    - if [ $TRAVIS_OS_NAME = "linux" ]; then julia -e 'Pkg.add("Documenter")'; fi
+    - if [ $TRAVIS_OS_NAME = "linux" ]; then $TESTCMD 'cd(Pkg.dir("FeigenbaumUtil")); include(joinpath("docs", "make.jl"))'; fi
     # push coverage results to Coveralls
-    - if [[ `uname` = "Linux" ]]; then julia -e 'cd(Pkg.dir("FeigenbaumUtil")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi
+    - if [ $TRAVIS_OS_NAME = "linux" ]; then julia -e 'cd(Pkg.dir("FeigenbaumUtil")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi
     # push coverage results to Codecov
-    - if [[ `uname` = "Linux" ]]; then julia -e 'cd(Pkg.dir("FeigenbaumUtil")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'; fi
+    - if [ $TRAVIS_OS_NAME = "linux" ]; then julia -e 'cd(Pkg.dir("FeigenbaumUtil")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'; fi
 sudo: required

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ environment:
   matrix:
   - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
 
 branches:
   only:


### PR DESCRIPTION
(only one build would be even better...)

The only platform dependent code is graphics code, which is only run on Linux anyways.
Maybe consider reducing to doing so only for one entry in the build matrix, since functionality should also be stable between Julia releases?